### PR TITLE
Fix flatpak-external-data-checker annotation

### DIFF
--- a/org.scilab.Scilab.yaml
+++ b/org.scilab.Scilab.yaml
@@ -71,10 +71,10 @@ modules:
       - type: archive
         url: https://www.scilab.org/download/6.1.1/scilab-6.1.1.bin.linux-x86_64.tar.gz
         sha256: 3ee1a7cf661d021ae26afc27b9fe50cb2d1c9c27911e5582e9d4337ebedb2c79
-      - type: patch
-        path: fix-appdata.patch
         x-checker-data:
           type: anitya
           project-id: 6367
           stable-only: true
-          url-template: https://www.scilab.org/download/$version/scilab-$version.bin.linux-x86_64.tar.gz
+          url-template: https://www.scilab.org/download/$version/scilab-$version.bin.x86_64-pc-linux-gnu.tar.xz
+      - type: patch
+        path: fix-appdata.patch


### PR DESCRIPTION
The x-checker-data dictionary needs to be part of the 'archive' source, not the appdata patch.

Having fixed that — and having also fixed
https://release-monitoring.org/project/6367/ for the project having moved to GitLab — it appears the latest version has a new URL pattern. Update that too.

An update to 2023.0.0 should be proposed shortly after merging this PR. I am on a slow network connection, and testing this involves pulling the quarter-gigabyte tarball, so I haven't been able to testing this end-to-end, but it looks like it should work.